### PR TITLE
Add $apply, include dist, autovivify on nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-dist/

--- a/dist/update.js
+++ b/dist/update.js
@@ -1,0 +1,210 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+exports.default = update;
+/*
+React-compatible data-structure update utility
+
+(C) 2016-2017 Doug Hoyte
+2-clause BSD license
+*/
+
+function shallowCopyObject(x) {
+    return Object.assign(new x.constructor(), x);
+}
+
+function shallowCopyArray(x) {
+    return x.concat();
+}
+
+function update(view, upd) {
+    if ((typeof upd === 'undefined' ? 'undefined' : _typeof(upd)) !== 'object') throw new Error("update is not an object");
+
+    // Process commands:
+
+    if (upd.hasOwnProperty('$set')) {
+        return upd['$set'];
+    }
+
+    if (upd.hasOwnProperty('$unset')) {
+        if (view === undefined) view = {};
+
+        if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) !== 'object') throw new Error("view is not an object in unset");
+
+        var new_view = shallowCopyObject(view);
+        delete new_view[upd['$unset']];
+
+        return new_view;
+    }
+
+    if (upd.hasOwnProperty('$merge')) {
+        if (view === undefined) view = {};
+
+        if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) !== 'object') throw new Error("view is not an object in merge");
+        if ((typeof upd === 'undefined' ? 'undefined' : _typeof(upd)) !== 'object') throw new Error("update is not an object in merge");
+
+        var _new_view = shallowCopyObject(view);
+
+        Object.assign(_new_view, upd['$merge']);
+
+        return _new_view;
+    }
+
+    if (upd.hasOwnProperty('$push')) {
+        if (view === undefined) view = [];
+
+        if (!Array.isArray(view)) throw new Error("view is not an array in push");
+        if (!Array.isArray(upd['$push'])) throw new Error("update is not an array in push");
+
+        var _new_view2 = shallowCopyArray(view);
+
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
+
+        try {
+            for (var _iterator = upd['$push'][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                var e = _step.value;
+
+                _new_view2.push(e);
+            }
+        } catch (err) {
+            _didIteratorError = true;
+            _iteratorError = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion && _iterator.return) {
+                    _iterator.return();
+                }
+            } finally {
+                if (_didIteratorError) {
+                    throw _iteratorError;
+                }
+            }
+        }
+
+        return _new_view2;
+    }
+
+    if (upd.hasOwnProperty('$unshift')) {
+        if (view === undefined) view = [];
+
+        if (!Array.isArray(view)) throw new Error("view is not an array in unshift");
+        if (!Array.isArray(upd['$unshift'])) throw new Error("update is not an array in unshift");
+
+        var _new_view3 = shallowCopyArray(view);
+
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
+
+        try {
+            for (var _iterator2 = upd['$unshift'].reverse()[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                var _e = _step2.value;
+
+                _new_view3.unshift(_e);
+            }
+        } catch (err) {
+            _didIteratorError2 = true;
+            _iteratorError2 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                    _iterator2.return();
+                }
+            } finally {
+                if (_didIteratorError2) {
+                    throw _iteratorError2;
+                }
+            }
+        }
+
+        return _new_view3;
+    }
+
+    if (upd.hasOwnProperty('$splice')) {
+        if (view === undefined) view = [];
+
+        if (!Array.isArray(view)) throw new Error("view is not an array in splice");
+        if (!Array.isArray(upd['$splice'])) throw new Error("update is not an array in splice");
+
+        var _new_view4 = shallowCopyArray(view);
+
+        var _iteratorNormalCompletion3 = true;
+        var _didIteratorError3 = false;
+        var _iteratorError3 = undefined;
+
+        try {
+            for (var _iterator3 = upd['$splice'][Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                var s = _step3.value;
+
+                if (!Array.isArray(s)) throw new Error("update element is not an array");
+                _new_view4.splice.apply(_new_view4, s);
+            }
+        } catch (err) {
+            _didIteratorError3 = true;
+            _iteratorError3 = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                    _iterator3.return();
+                }
+            } finally {
+                if (_didIteratorError3) {
+                    throw _iteratorError3;
+                }
+            }
+        }
+
+        return _new_view4;
+    }
+
+    if (upd.hasOwnProperty('$apply')) {
+        if (view === undefined) view = {};
+        if (typeof upd['$apply'] !== 'function') throw new Error("update is not a function in apply");
+
+        var _new_view5 = void 0;
+
+        if (Array.isArray(view)) {
+            _new_view5 = shallowCopyArray(view);
+        } else if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) === 'object') {
+            _new_view5 = shallowCopyObject(view);
+        } else if (view !== Object(view)) {
+            _new_view5 = view;
+        }
+
+        if (_new_view5 === undefined) throw new Error("view is not an object, array or primitive");
+        return upd['$apply'](_new_view5);
+    }
+
+    // Recurse to handle nested commands in upd:
+
+    if (view === undefined) view = {};
+
+    if (Array.isArray(view)) {
+        var output = shallowCopyArray(view);
+
+        for (var key in upd) {
+            var int = parseInt(key);
+            if (key != int) throw new Error("non-numeric key in array update"); // deliberate != instead of !==
+            output[int] = update(output[int], upd[key]);
+        }
+
+        return output;
+    } else if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) === 'object') {
+        var _output = shallowCopyObject(view);
+
+        for (var _key in upd) {
+            _output[_key] = update(_output[_key], upd[_key]);
+        }
+
+        return _output;
+    }
+
+    throw new Error("view not an array or hash");
+}

--- a/dist/update.js
+++ b/dist/update.js
@@ -32,7 +32,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$unset')) {
-        if (view === undefined) view = {};
+        if (view === undefined || view === null) view = {};
 
         if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) !== 'object') throw new Error("view is not an object in unset");
 
@@ -43,7 +43,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$merge')) {
-        if (view === undefined) view = {};
+        if (view === undefined || view === null) view = {};
 
         if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) !== 'object') throw new Error("view is not an object in merge");
         if ((typeof upd === 'undefined' ? 'undefined' : _typeof(upd)) !== 'object') throw new Error("update is not an object in merge");
@@ -56,7 +56,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$push')) {
-        if (view === undefined) view = [];
+        if (view === undefined || view === null) view = [];
 
         if (!Array.isArray(view)) throw new Error("view is not an array in push");
         if (!Array.isArray(upd['$push'])) throw new Error("update is not an array in push");
@@ -92,7 +92,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$unshift')) {
-        if (view === undefined) view = [];
+        if (view === undefined || view === null) view = [];
 
         if (!Array.isArray(view)) throw new Error("view is not an array in unshift");
         if (!Array.isArray(upd['$unshift'])) throw new Error("update is not an array in unshift");
@@ -128,7 +128,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$splice')) {
-        if (view === undefined) view = [];
+        if (view === undefined || view === null) view = [];
 
         if (!Array.isArray(view)) throw new Error("view is not an array in splice");
         if (!Array.isArray(upd['$splice'])) throw new Error("update is not an array in splice");
@@ -165,7 +165,7 @@ function update(view, upd) {
     }
 
     if (upd.hasOwnProperty('$apply')) {
-        if (view === undefined) view = {};
+        if (view === undefined || view === null) view = {};
         if (typeof upd['$apply'] !== 'function') throw new Error("update is not a function in apply");
 
         var _new_view5 = void 0;
@@ -184,7 +184,7 @@ function update(view, upd) {
 
     // Recurse to handle nested commands in upd:
 
-    if (view === undefined) view = {};
+    if (view === undefined || view === null) view = {};
 
     if (Array.isArray(view)) {
         var output = shallowCopyArray(view);

--- a/t/basic.js
+++ b/t/basic.js
@@ -180,6 +180,13 @@ apply_update(test,
 );
 
 apply_update(test,
+  "apply, auto-vivify null",
+  { a: { b: null }, c: 2 },
+  { a: { b: { '$apply': (val) => 5 } } },
+  { a: { b: 5 }, c: 2 }
+);
+
+apply_update(test,
   "apply array",
   { a: [ 2, ], },
   { a: { 0: { '$apply': (val) => val * 2 } } },

--- a/t/basic.js
+++ b/t/basic.js
@@ -163,6 +163,29 @@ apply_update(test,
   { a: [ 8, 9 ] }
 );
 
+// apply
+
+apply_update(test,
+  "apply",
+  { a: { b: 3, z: 2 }, c: 2 },
+  { a: { b: { '$apply': (val) => val * 2} } },
+  { a: { b: 6, z: 2 }, c: 2 }
+);
+
+apply_update(test,
+  "apply, auto-vivify",
+  { c: 2 },
+  { a: { b: { '$apply': (val) => 5 } } },
+  { a: { b: 5 }, c: 2 }
+);
+
+apply_update(test,
+  "apply array",
+  { a: [ 2, ], },
+  { a: { 0: { '$apply': (val) => val * 2 } } },
+  { a: [ 4 ] }
+);
+
 
     test.done();
 };

--- a/update.js
+++ b/update.js
@@ -25,7 +25,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$unset')) {
-    if (view === undefined) view = {};
+    if (view === undefined || view === null) view = {};
 
     if (typeof(view) !== 'object') throw(new Error("view is not an object in unset"));
 
@@ -36,7 +36,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$merge')) {
-    if (view === undefined) view = {};
+    if (view === undefined || view === null) view = {};
 
     if (typeof(view) !== 'object') throw(new Error("view is not an object in merge"));
     if (typeof(upd) !== 'object') throw(new Error("update is not an object in merge"));
@@ -49,7 +49,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$push')) {
-    if (view === undefined) view = [];
+    if (view === undefined || view === null) view = [];
 
     if (!Array.isArray(view)) throw(new Error("view is not an array in push"));
     if (!Array.isArray(upd['$push'])) throw(new Error("update is not an array in push"));
@@ -64,7 +64,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$unshift')) {
-    if (view === undefined) view = [];
+    if (view === undefined || view === null) view = [];
 
     if (!Array.isArray(view)) throw(new Error("view is not an array in unshift"));
     if (!Array.isArray(upd['$unshift'])) throw(new Error("update is not an array in unshift"));
@@ -79,7 +79,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$splice')) {
-    if (view === undefined) view = [];
+    if (view === undefined || view === null) view = [];
 
     if (!Array.isArray(view)) throw(new Error("view is not an array in splice"));
     if (!Array.isArray(upd['$splice'])) throw(new Error("update is not an array in splice"));
@@ -95,7 +95,7 @@ export default function update(view, upd) {
   }
 
   if (upd.hasOwnProperty('$apply')) {
-    if (view === undefined) view = {};
+    if (view === undefined || view === null) view = {};
     if (typeof(upd['$apply']) !== 'function') throw(new Error("update is not a function in apply"));
 
     let new_view;
@@ -115,7 +115,7 @@ export default function update(view, upd) {
 
   // Recurse to handle nested commands in upd:
 
-  if (view === undefined) view = {};
+  if (view === undefined || view === null) view = {};
 
   if (Array.isArray(view)) {
     let output = shallowCopyArray(view);

--- a/update.js
+++ b/update.js
@@ -94,6 +94,24 @@ export default function update(view, upd) {
     return new_view;
   }
 
+  if (upd.hasOwnProperty('$apply')) {
+    if (view === undefined) view = {};
+    if (typeof(upd['$apply']) !== 'function') throw(new Error("update is not a function in apply"));
+
+    let new_view;
+
+    if (Array.isArray(view)) {
+      new_view = shallowCopyArray(view);
+    } else if (typeof(view) === 'object') {
+      new_view = shallowCopyObject(view);
+    } else if (view !== Object(view)) {
+      new_view = view;
+    }
+
+    if (new_view === undefined) throw(new Error("view is not an object, array or primitive"));
+    return upd['$apply'](new_view);
+  }
+
 
   // Recurse to handle nested commands in upd:
 


### PR DESCRIPTION
Hello, thanks for making this library that solves our frustrations!

This PR adds 3 features:
- The `$apply` method
- Autovivify on nil: `view === undefined || view === null`
- Include built files so that the library can be added directly from git

I am not sure if auto-vivifying on null is such a good idea since it's usually present in a collection intentionally. However, without it we had to resort to the same deep checks as with [immutability-helper](https://github.com/kolodny/immutability-helper). Maybe it could be an option?

I'll gladly make changes or add more tests if needed.