### PR TITLE
No shallow copy on update with same value primitive

### DIFF
--- a/dist/update.js
+++ b/dist/update.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 exports.default = update;
 /*
@@ -216,22 +216,30 @@ function update(view, upd) {
 
   if (Array.isArray(view)) {
     var output = shallowCopyArray(view);
+    var changed = false;
 
     for (var key in upd) {
       var int = parseInt(key);
-      if (key != int) throw new Error("non-numeric key in array update"); // deliberate != instead of !==
+      if (key != int) throw new Error('non-numeric key in array update'); // deliberate != instead of !==
       output[int] = update(output[int], upd[key]);
+      if (output[int] !== view[int]) {
+        changed = true;
+      }
     }
 
-    return output;
+    return changed ? output : view;
   } else if ((typeof view === 'undefined' ? 'undefined' : _typeof(view)) === 'object') {
     var _output = shallowCopyObject(view);
+    var _changed = false;
 
     for (var _key in upd) {
       _output[_key] = update(_output[_key], upd[_key]);
+      if (_output[_key] !== view[_key]) {
+        _changed = true;
+      }
     }
 
-    return _output;
+    return _changed ? _output : view;
   }
 
   throw new Error("view not an array or hash");

--- a/t/basic.js
+++ b/t/basic.js
@@ -15,6 +15,16 @@ function apply_update(test, desc, input, update_v, expected) {
     test.deepEqual(input, orig, "original not modified: " + desc);
 }
 
+function apply_primitive_update(test, desc, input, update_v, expected) {
+  var orig = clone(input);
+
+  var output = update(input, update_v);
+
+  test.deepEqual(output, expected, "update applied correctly: " + desc);
+  test.ok(input === output, "shallow equality retained: " + desc);
+  test.deepEqual(input, orig, "original not modified: " + desc);
+}
+
 
 exports.testUpdate = function(test){
 
@@ -207,6 +217,28 @@ apply_update(test,
   { a: [ 4 ] }
 );
 
+// Retain shallow equality
+
+apply_primitive_update(test,
+  "simple set, no update",
+  { a: 1 },
+  { a: { $set: 1} },
+  { a: 1 }
+);
+
+apply_primitive_update(test,
+  "nested set, no update",
+  { a: { b: 1 }, c: 2 },
+  { a: { b: { '$set': 1 } } },
+  { a: { b: 1 }, c: 2 }
+);
+
+apply_primitive_update(test,
+  "set array, no update",
+  { a: [ 9, ], },
+  { a: { 0: { '$set': 9 } } },
+  { a: [ 9 ] }
+);
 
 
 // misc

--- a/update.js
+++ b/update.js
@@ -126,22 +126,30 @@ export default function update(view, upd) {
 
   if (Array.isArray(view)) {
     let output = shallowCopyArray(view);
+    let changed = false;
 
     for (let key in upd) {
-        let int = parseInt(key);
-        if (key != int) throw(new Error("non-numeric key in array update")); // deliberate != instead of !==
+        const int = parseInt(key);
+        if (key != int) throw new Error('non-numeric key in array update'); // deliberate != instead of !==
         output[int] = update(output[int], upd[key]);
+        if (output[int] !== view[int]) {
+          changed = true;
+        }
     }
 
-    return output;
+    return changed ? output : view;
   } else if (typeof(view) === 'object') {
     let output = shallowCopyObject(view);
+    let changed = false;
 
     for (let key in upd) {
         output[key] = update(output[key], upd[key]);
+        if (output[key] !== view[key]) {
+          changed = true;
+        }
     }
 
-    return output;
+    return changed ? output : view;
   }
 
   throw(new Error("view not an array or hash"));


### PR DESCRIPTION
This preserves reference equality without doing deep checks. It's in line with immutability-helper as far as I can tell.

Addresses #3 and the TODO on the readme which I should've read :)